### PR TITLE
Resolve all imports in current buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ## Configuration
 
-Mappings are not set by default, hence it's required to set a mapping for resolving import:
+Mappings are not set by default, hence it's required to set a mapping for resolving imports:
 
 ```lua
 vim.keymap.set("n", "<leader>a", require("lspimport").import, { noremap = true })
 ```
 
-Once mapping is set, jump on the line with an undefined term and execute
-mapping to resolve import.
+Once mapping is set, execute mapping to resolve imports in the current buffer.
 
 ## Supported language servers
 

--- a/lua/lspimport/init.lua
+++ b/lua/lspimport/init.lua
@@ -5,8 +5,7 @@ local LspImport = {}
 
 ---@return Diagnostic[]
 local get_unresolved_import_errors = function()
-    local line, _ = unpack(vim.api.nvim_win_get_cursor(0))
-    local diagnostics = vim.diagnostic.get(0, { lnum = line - 1, severity = vim.diagnostic.severity.ERROR })
+    local diagnostics = vim.diagnostic.get(0, { severity = vim.diagnostic.severity.ERROR })
     if vim.tbl_isempty(diagnostics) then
         return {}
     end
@@ -18,19 +17,6 @@ local get_unresolved_import_errors = function()
         end
         return server.is_unresolved_import_error(diagnostic)
     end, diagnostics)
-end
-
----@param diagnostics Diagnostic[]
----@return Diagnostic|nil
-local get_diagnostic_under_cursor = function(diagnostics)
-    local cursor = vim.api.nvim_win_get_cursor(0)
-    local row, col = cursor[1] - 1, cursor[2]
-    for _, d in ipairs(diagnostics) do
-        if d.lnum <= row and d.col <= col and d.end_lnum >= row and d.end_col >= col then
-            return d
-        end
-    end
-    return nil
 end
 
 ---@param server lspimport.Server
@@ -127,8 +113,9 @@ LspImport.import = function()
             vim.notify("no unresolved import error")
             return
         end
-        local diagnostic = get_diagnostic_under_cursor(diagnostics)
-        lsp_completion(diagnostic or diagnostics[1])
+        for _, diagnostic in ipairs(diagnostics) do
+            lsp_completion(diagnostic)
+        end
     end)
 end
 


### PR DESCRIPTION
The plugin is not very helpful when we need to resolve imports line by line.
It is also convenient to use regular cmp in such cases.

Usually, we have multiple lines of unknown imports and we would like to resolve them without moving cursor automatically.
This PR attempts to resolve every unknown import in the current buffer.