### PR TITLE
Include missing imports by changing how the diagnostics are filtered out

### DIFF
--- a/lua/lspimport/init.lua
+++ b/lua/lspimport/init.lua
@@ -54,14 +54,14 @@ local get_auto_import_complete_items = function(server, result, unresolved_impor
     if vim.tbl_isempty(items) then
         return {}
     end
+
     return vim.tbl_filter(function(item)
         return item.word == unresolved_import
             and item.user_data
             and item.user_data.nvim
             and item.user_data.nvim.lsp.completion_item
-            and item.user_data.nvim.lsp.completion_item.labelDetails
-            and item.user_data.nvim.lsp.completion_item.labelDetails.description
-            and item.user_data.nvim.lsp.completion_item.additionalTextEdits
+            and item.user_data.nvim.lsp.completion_item.data
+            and item.user_data.nvim.lsp.completion_item.data.autoImportText
             and not vim.tbl_isempty(item.user_data.nvim.lsp.completion_item.additionalTextEdits)
             and server.is_auto_import_completion_item(item)
     end, items)
@@ -79,7 +79,10 @@ end
 
 ---@param item any
 local format_import = function(item)
-    return item.abbr .. " " .. item.kind .. " " .. item.user_data.nvim.lsp.completion_item.labelDetails.description
+    local suggested_import = vim.fn.trim(item.user_data.nvim.lsp.completion_item.data.autoImportText, "```")
+    local item_info = string.format("%s [%s]", item.abbr, item.kind)
+
+    return string.format("%-20s %s", item_info, suggested_import)
 end
 
 ---@param server lspimport.Server


### PR DESCRIPTION
Thanks for the awesome plugin! I wanted to write something similar but I'm so glad I checked to see what's out there and was delighted to see this project :)

As discussed in #1  the plugin doesn't suggest all the possible imports and I did some digging and found the root cause. For some reason not all diagnostic items have `item.user_data.nvim.lsp.completion_item.labelDetails.description`. The plugin is filtering these out as it needs it in the display but nothing else it seems. I replaced this with `item.user_data.nvim.lsp.completion_item.data.autoImportText` which seems to contain the import statement to be added, so I used that instead.

This makes the change not strictly backwards-compatible but couldn't find another way to do it and personally I prefer to see the exact import in the list. We can also extract the `format_import` function into a config option in the future but I think it's fine as it is (for my needs at least).

Another option is to use the `item.user_data.nvim.lsp.completion_item.additionalTextEdits.[].newText` as this contains the exact changes that will be applied but that has weird edge cases I didn't want to both implementing. For example, if the file already contains `from typing import Any` and we want to autoimport `dataclass_transform`, the values of `newText` would be `from typing_extensions import dataclass_transform` and `, dataclass_transofrm`, the latter referring to appending to the existing import.